### PR TITLE
Add vector norm test

### DIFF
--- a/tests/numpy/linalg.py
+++ b/tests/numpy/linalg.py
@@ -106,19 +106,18 @@ result = (np.linalg.norm(a))  ## Here is a problem
 ref_result = 16.881943016134134
 print(math.isclose(result, ref_result, rel_tol=1E-6, abs_tol=1E-6))
 
-
 a = np.array([[0, 1, 2], [3, 4 ,5], [5, 4, 8], [4, 4, 8] ], dtype=np.int16)
-result = (np.linalg.norm(a,axis=0)) # fails on low tolerance when result >10?
+result = (np.linalg.norm(a,axis=0)) # fails on low tolerance 
 ref_result = np.array([7.071068, 7.0, 12.52996])
 for i in range(3):
         print(math.isclose(result[i], ref_result[i], rel_tol=1E-6, abs_tol=1E-6))
 
 a = np.array([[0, 1, 2], [3, 4 ,5], [5, 4, 8], [4, 4, 8] ], dtype=np.int16)
-result = (np.linalg.norm(a,axis=1)). # fails on low tolerance when result >10?
+result = (np.linalg.norm(a,axis=1)) # fails on low tolerance 
 ref_result = np.array([2.236068, 7.071068, 10.24695, 9.797959])
 for i in range(4):
         print(math.isclose(result[i], ref_result[i], rel_tol=1E-6, abs_tol=1E-6))
-        
+
 if use_ulab:
     print(np.linalg.trace(np.eye(3)))
 else:

--- a/tests/numpy/linalg.py
+++ b/tests/numpy/linalg.py
@@ -106,10 +106,17 @@ result = (np.linalg.norm(a))  ## Here is a problem
 ref_result = 16.881943016134134
 print(math.isclose(result, ref_result, rel_tol=1E-6, abs_tol=1E-6))
 
-a = np.array([[0, 1, 2], [5, 4, 8], [4, 4, 8] ], dtype=np.int16)
-result = (np.linalg.norm(a,axis=1))
-ref_result = np.array([2.236068, 10.24695, 9.797959]) #Problem when element > 10?
+
+a = np.array([[0, 1, 2], [3, 4 ,5], [5, 4, 8], [4, 4, 8] ], dtype=np.int16)
+result = (np.linalg.norm(a,axis=0)) # fails on low tolerance when result >10?
+ref_result = np.array([7.071068, 7.0, 12.52996])
 for i in range(3):
+        print(math.isclose(result[i], ref_result[i], rel_tol=1E-6, abs_tol=1E-6))
+
+a = np.array([[0, 1, 2], [3, 4 ,5], [5, 4, 8], [4, 4, 8] ], dtype=np.int16)
+result = (np.linalg.norm(a,axis=1)). # fails on low tolerance when result >10?
+ref_result = np.array([2.236068, 7.071068, 10.24695, 9.797959])
+for i in range(4):
         print(math.isclose(result[i], ref_result[i], rel_tol=1E-6, abs_tol=1E-6))
         
 if use_ulab:

--- a/tests/numpy/linalg.py
+++ b/tests/numpy/linalg.py
@@ -106,6 +106,12 @@ result = (np.linalg.norm(a))  ## Here is a problem
 ref_result = 16.881943016134134
 print(math.isclose(result, ref_result, rel_tol=1E-6, abs_tol=1E-6))
 
+a = np.array([[0, 1, 2], [5, 4, 8], [4, 4, 8] ], dtype=np.int16)
+result = (np.linalg.norm(a,axis=1))
+ref_result = np.array([2.236068, 10.24695, 9.797959]) #Problem when element > 10?
+for i in range(3):
+        print(math.isclose(result[i], ref_result[i], rel_tol=1E-6, abs_tol=1E-6))
+        
 if use_ulab:
     print(np.linalg.trace(np.eye(3)))
 else:

--- a/tests/numpy/linalg.py.exp
+++ b/tests/numpy/linalg.py.exp
@@ -44,4 +44,11 @@ True
 True
 True
 True
+True
+True
+True
+True
+True
+True
+True
 3.0


### PR DESCRIPTION
Test passes with tolerance of 1E6, but seems to fail for element >10, initial array was chosen to creates results either side of that line 